### PR TITLE
Fix `date-format` bug in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The date format is `YYYY-MM-DD`.
 
 ## [Unreleased]
+- Fixed `date-format` bug in header
 
 ## [0.3.3] - 2025-09-22
 No information available.

--- a/src/header.typ
+++ b/src/header.typ
@@ -30,10 +30,10 @@
 
     // left
     header-section((
-      if date != none {
-        context date.display(if date-format != none { date-format } else { i18n.default-date() })
-      },
-      if date-format != none { datetime.today().display(date-format) },
+      if date != none { context {
+        let format = if date-format != none { date-format } else { i18n.default-date() }
+        date.display(format)
+      }},
       if tutor != none [Tutor: #tutor],
       extra-left,
     )),


### PR DESCRIPTION
Resolves #1.

There was a bug where the `date-format` option for the header resulted in unexpected behavior (resulting from a old version of the feature). This is fixed now.