### PR TITLE
Change date setup options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [Unreleased]
 - Fixed `date-format` bug in header
+- Changed `setup` options: (BREAKING)
+  - `header-date` -> `date`
+  - `header-date-format` -> `date-format`
 
 ## [0.3.3] - 2025-09-22
 No information available.

--- a/src/setup.typ
+++ b/src/setup.typ
@@ -35,8 +35,9 @@
   paper: "a4",
   page-numbering: "1 / 1",
 
-  header-date: datetime.today(),
-  header-date-format: none,
+  date: datetime.today(),
+  date-format: none,
+
   header-show-title-on-first-page: false,
   header-extra-left: none,
   header-extra-center: none,
@@ -92,8 +93,8 @@
     title: title,
     authors: author-names,
     tutor: tutor,
-    date: header-date,
-    date-format: header-date-format,
+    date: date,
+    date-format: date-format,
     show-title-on-first-page: header-show-title-on-first-page,
     extra-left: header-extra-left,
     extra-center: header-extra-center,


### PR DESCRIPTION
This changes the names of two options in the main `setup` function.
- `header-date` is now `date`
- `header-date-format` is now `date-format`