### PR TITLE
Change task number update behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed `setup` options: (BREAKING)
   - `header-date` -> `date`
   - `header-date-format` -> `date-format`
+- Changed task number update behavior
 
 ## [0.3.3] - 2025-09-22
 No information available.

--- a/src/setup.typ
+++ b/src/setup.typ
@@ -139,7 +139,7 @@
     //
 
     let task-counter = counter("sheetstorm-task")
-    task-counter.update(initial-task-number - 1)
+    task-counter.update(initial-task-number)
 
     //
     // SPACING BELOW HEADER

--- a/src/task.typ
+++ b/src/task.typ
@@ -30,7 +30,7 @@
   content,
 ) = {
   let task-count = counter("sheetstorm-task")
-  if counter-reset == none { task-count.step() } else { task-count.update(counter-reset) }
+  if counter-reset != none { task-count.update(counter-reset) }
 
   let points-enabled = false
   let current-points
@@ -85,4 +85,6 @@
     })
     #content
   ]
+
+  task-count.step()
 }


### PR DESCRIPTION
Previously, the task number was bumped _before_ the new task.
Now it gets bumped _after_ a new task.

This has the advantage that `initial-task-number` can be `0` now.

But it also slightly changes the meaning of the `counter-reset` argument of the `task` function.