### PR TITLE
Hide empty score box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `header-date` -> `date`
   - `header-date-format` -> `date-format`
 - Changed task number update behavior
+- Fixed empty score box, hide it when no tasks
 
 ## [0.3.3] - 2025-09-22
 No information available.

--- a/src/widgets.typ
+++ b/src/widgets.typ
@@ -46,9 +46,15 @@
     display-points = (point-list + (points-sum,)).map(p =>
       if show-points and p != none [\/ #p] else { empty }
     )
+  } else if type(tasks) != array {
+    return none
   } else {
     display-tasks = tasks.map(to-content)
     display-points = tasks.map(_ => empty)
+  }
+
+  if display-tasks.len() == 0 {
+    return none
   }
 
   table(


### PR DESCRIPTION
Resolves #3.

Only show the score box when there is at least a one task.

Also add some checks for a well-formed `tasks` input.