### PR TITLE
Add some metadata to generated PDFs

### DIFF
--- a/src/assignment.typ
+++ b/src/assignment.typ
@@ -252,6 +252,13 @@
 ) = context {
   let (author-names, author-ids, author-emails) = _handle_authors(authors)
 
+  set document(
+    author: if author-names.all(n => type(n) == str) {
+      if author-names.len() == 1 { author-names.first() } else { author-names }
+    } else { () },
+    title: title,
+  )
+
   let header = header-content(
     course,
     title,


### PR DESCRIPTION
This adds some metadata to the generated PDFs. Namely a title and the names of the authors if possible.

Resolves #41 