### PR TITLE
Rename `i18n.word` to `i18n.translate`

### DIFF
--- a/src/appendix.typ
+++ b/src/appendix.typ
@@ -14,11 +14,11 @@
 /// -> content
 #let appendix(
   /// The title of the whole appendix. -> content | str | none
-  title: context i18n.word("Appendix"),
+  title: context i18n.translate("Appendix"),
   /// The text size of the appendix title. -> length
   title-size: 1.6em,
   /// The supplement of the appendix sections. -> content | str | function | none
-  supplement: context i18n.word("Appendix"),
+  supplement: context i18n.translate("Appendix"),
   /// The numbering pattern for the appendix sections. -> str | none
   numbering: "A.1.",
   /// The appendix body itself. -> content

--- a/src/assignment.typ
+++ b/src/assignment.typ
@@ -169,7 +169,7 @@
   /// Extra content that is displayed in the right header column. -> content | str
   header-extra-right: none,
   /// The word that prefixes the tutor name in the header. -> content | str
-  header-tutor-prefix: context i18n.word("Tutor"),
+  header-tutor-prefix: context i18n.translate("Tutor"),
   /// The columns settings of the header.
   ///
   /// This can break the entire header if you play with it carelessly.

--- a/src/i18n.typ
+++ b/src/i18n.typ
@@ -1,4 +1,4 @@
-#let _words = (
+#let _translations = (
   // Task related
   Task: (
     de: "Aufgabe",
@@ -32,12 +32,11 @@
   de: "[day].[month].[year]",
 )
 
-#let word(key) = {
-  if not key in _words {
+#let translate(key) = {
+  if not key in _translations {
     return key
   }
-
-  _words.at(key).at(text.lang, default: key)
+  _translations.at(key).at(text.lang, default: key)
 }
 
 #let date-format() = {

--- a/src/labelling.typ
+++ b/src/labelling.typ
@@ -34,6 +34,6 @@
     display = lbl
   }
 
-  let supplement = [#context i18n.word("Subtask") #display]
+  let supplement = [#context i18n.translate("Subtask") #display]
   impromptu-label(lbl, kind: "sheetstorm-subtask-label", supplement: supplement)
 }

--- a/src/task.typ
+++ b/src/task.typ
@@ -39,7 +39,7 @@
   /// The name of the task. -> content | str | none
   name: none,
   /// The prefix that is displayed before the task count. -> content | str
-  task-prefix: context i18n.word("Task"),
+  task-prefix: context i18n.translate("Task"),
   /// A label that you can reference or query. -> str | none
   label: none,
   /// The supplement of the task which is used in outlines and references.
@@ -91,7 +91,7 @@
   /// Whether to show the points on the right side of the page above the task. -> bool
   points-show: true,
   /// The word that is displayed before the points. -> content | str
-  points-prefix: context i18n.word("Points"),
+  points-prefix: context i18n.translate("Points"),
   /// Whether the task is a bonus task. -> bool
   bonus: false,
   /// Whether bonus tasks are marked with a star in the title. -> bool

--- a/src/theorem.typ
+++ b/src/theorem.typ
@@ -10,7 +10,7 @@
 /// -> content
 #let theorem(
   /// The theorem kind which is displayed as prefix. -> content | str
-  kind: context i18n.word("Theorem"),
+  kind: context i18n.translate("Theorem"),
   /// The numbering of the theorem.
   ///
   /// - #auto: Use an automatic counter.
@@ -107,10 +107,10 @@
 }
 
 /// Corollary environment, based on the `theorem` environment.
-#let corollary = theorem.with(kind: context i18n.word("Corollary"))
+#let corollary = theorem.with(kind: context i18n.translate("Corollary"))
 
 /// Lemma environment, based on the `theorem` environment.
-#let lemma = theorem.with(kind: context i18n.word("Lemma"))
+#let lemma = theorem.with(kind: context i18n.translate("Lemma"))
 
 /// Proof environment.
 ///
@@ -123,7 +123,7 @@
   /// The symbol that marks the end of the proof. -> content
   qed: $square$,
   /// The prefix that displayed at the beginning of the proof. -> content | str
-  prefix: context i18n.word("Proof"),
+  prefix: context i18n.translate("Proof"),
   /// The styling of the `prefix`. -> function
   prefix-style: p => [_#p._],
   /// The `fill` value of the proof box. -> none | color | gradient | tiling


### PR DESCRIPTION
Resolves #49 